### PR TITLE
Add support for better formatting in toJson() method.

### DIFF
--- a/lodash-plugin/src/main/java/com/github/underscore/lodash/$.java
+++ b/lodash-plugin/src/main/java/com/github/underscore/lodash/$.java
@@ -1163,8 +1163,74 @@ public class $<T> extends com.github.underscore.$<T> {
         return result + omission;
     }
 
+    public static class JsonStringBuilder {
+        private final StringBuilder builder;
+        private int ident;
+        private boolean newString;
+        private boolean newKey;
+        private boolean newLine;
+
+        public JsonStringBuilder() {
+            builder = new StringBuilder();
+        }
+
+        public JsonStringBuilder append(final char character) {
+            switch (character) {
+                case '[':
+                case '{':
+                    fillSpaces(newLine);
+                    ident += 2;
+                    break;
+                case ']':
+                case '}':
+                    ident -= 2;
+                    builder.append("\n");
+                    fillSpaces(true);
+                    break;
+                case '\"':
+                    newString = !newString;
+                    fillSpaces(newString && !newKey);
+                    break;
+                default:
+                    break;
+            }
+            builder.append(character);
+            if (character == ',' || character == '[' || character == '{') {
+                builder.append("\n");
+                newLine = true;
+            } else {
+                newLine = false;
+            }
+            if (character == ':') {
+                builder.append(' ');
+                newKey = true;
+            } else {
+                newKey = false;
+            }
+            return this;
+        }
+
+        public JsonStringBuilder append(final String string) {
+            fillSpaces(!newString && !newKey);
+            builder.append(string);
+            return this;
+        }
+
+        private void fillSpaces(final boolean condition) {
+            if (condition) {
+                for (int index = 0; index < ident; index += 1) {
+                    builder.append(' ');
+                }
+            }
+        }
+
+        public String toString() {
+            return builder.toString();
+        }
+    }
+
     public static class JsonArray {
-        public static void writeJson(Collection collection, StringBuilder builder) {
+        public static void writeJson(Collection collection, JsonStringBuilder builder) {
             if (collection == null) {
                 builder.append(NULL);
                 return;
@@ -1192,7 +1258,7 @@ public class $<T> extends com.github.underscore.$<T> {
             builder.append(']');
         }
 
-        public static void writeJson(byte[] array, StringBuilder builder) {
+        public static void writeJson(byte[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1210,7 +1276,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(short[] array, StringBuilder builder) {
+        public static void writeJson(short[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1228,7 +1294,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(int[] array, StringBuilder builder) {
+        public static void writeJson(int[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1246,7 +1312,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(long[] array, StringBuilder builder) {
+        public static void writeJson(long[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1264,7 +1330,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(float[] array, StringBuilder builder) {
+        public static void writeJson(float[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1282,7 +1348,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(double[] array, StringBuilder builder) {
+        public static void writeJson(double[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1300,7 +1366,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(boolean[] array, StringBuilder builder) {
+        public static void writeJson(boolean[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1318,25 +1384,25 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(char[] array, StringBuilder builder) {
+        public static void writeJson(char[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
                 builder.append("[]");
             } else {
-                builder.append("[\"");
+                builder.append('[').append('\"');
                 builder.append(String.valueOf(array[0]));
 
                 for (int i = 1; i < array.length; i++) {
-                    builder.append("\",\"");
+                    builder.append('\"').append(',').append('\"');
                     builder.append(String.valueOf(array[i]));
                 }
 
-                builder.append("\"]");
+                builder.append('\"').append(']');
             }
         }
 
-        public static void writeJson(Object[] array, StringBuilder builder) {
+        public static void writeJson(Object[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -1356,7 +1422,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static class JsonObject {
-        public static void writeJson(Map map, StringBuilder builder) {
+        public static void writeJson(Map map, JsonStringBuilder builder) {
             if (map == null) {
                 builder.append(NULL);
                 return;
@@ -1384,7 +1450,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static class JsonValue {
-        public static void writeJson(Object value, StringBuilder builder) {
+        public static void writeJson(Object value, JsonStringBuilder builder) {
             if (value == null) {
                 builder.append(NULL);
             } else if (value instanceof String) {
@@ -1490,7 +1556,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static String toJson(Collection collection) {
-        final StringBuilder builder = new StringBuilder();
+        final JsonStringBuilder builder = new JsonStringBuilder();
 
         JsonArray.writeJson(collection, builder);
         return builder.toString();
@@ -1501,7 +1567,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static String toJson(Map map) {
-        final StringBuilder builder = new StringBuilder();
+        final JsonStringBuilder builder = new JsonStringBuilder();
 
         JsonObject.writeJson(map, builder);
         return builder.toString();

--- a/lodash-plugin/src/test/java/com/github/underscore/lodash/StringTest.java
+++ b/lodash-plugin/src/test/java/com/github/underscore/lodash/StringTest.java
@@ -23,6 +23,12 @@
  */
 package com.github.underscore.lodash;
 
+import com.github.underscore.Block;
+import com.github.underscore.Function1;
+import com.github.underscore.FunctionAccum;
+import com.github.underscore.Predicate;
+import com.github.underscore.lodash.$.JsonStringBuilder;
+
 import java.util.*;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -390,53 +396,53 @@ _.repeat('abc', 0);
 
     @Test
     public void testJsonArray() {
-        StringBuilder builder = new StringBuilder();
+        JsonStringBuilder builder = new JsonStringBuilder();
         $.JsonArray.writeJson((Collection) null, builder);
         assertEquals("null", builder.toString());
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new ArrayList<String>() { { add((String) null); } }, builder);
-        assertEquals("[null]", builder.toString());
+        assertEquals("[\n  null\n]", builder.toString());
     }
 
     @Test
     public void testJsonArrayCollection() {
-        assertEquals("[\"First item\",\"Second item\"]",
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]",
             $.toJson(Arrays.asList("First item", "Second item")));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new byte[] {1, 2})));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new short[] {1, 2})));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new int[] {1, 2})));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new long[] {1, 2})));
-        assertEquals("[[1.0,2.0]]",
+        assertEquals("[\n  [\n    1.0,\n    2.0\n  ]\n]",
             $.toJson(Arrays.asList(new float[] {1, 2})));
-        assertEquals("[[1.0,2.0]]",
+        assertEquals("[\n  [\n    1.0,\n    2.0\n  ]\n]",
             $.toJson(Arrays.asList(new double[] {1, 2})));
-        assertEquals("[[\"1\",\"2\"]]",
+        assertEquals("[\n  [\n    \"1\",\n    \"2\"\n  ]\n]",
             $.toJson(Arrays.asList(new char[] {'1', '2'})));
-        assertEquals("[[true,false,true]]",
+        assertEquals("[\n  [\n    true,\n    false,\n    true\n  ]\n]",
             $.toJson(Arrays.asList(new boolean[] {true, false, true})));
-        assertEquals("[1.0,2.0]",
+        assertEquals("[\n  1.0,\n  2.0\n]",
             $.toJson(Arrays.asList(new Float[] {1F, 2F})));
-        assertEquals("[1.0,2.0]",
+        assertEquals("[\n  1.0,\n  2.0\n]",
             $.toJson(Arrays.asList(new Double[] {1D, 2D})));
-        assertEquals("[true,false,true]",
+        assertEquals("[\n  true,\n  false,\n  true\n]",
             $.toJson(Arrays.asList(new Boolean[] {true, false, true})));
-        assertEquals("[[\"First item\",\"Second item\"]]",
+        assertEquals("[\n  [\n    \"First item\",\n    \"Second item\"\n  ]\n]",
             $.toJson(Arrays.asList(Arrays.asList("First item", "Second item"))));
-        assertEquals("[{\"1\":\"First item\",\"2\":\"Second item\",\"3\":null}]",
+        assertEquals("[\n  {\n    \"1\": \"First item\",\n    \"2\": \"Second item\",\n    \"3\": null\n  }\n]",
             $.toJson(Arrays.asList(new LinkedHashMap() { {
                 put("1", "First item"); put("2", "Second item"); put("3", null); } })));
-        assertEquals("[null]", $.toJson(Arrays.asList(new String[] {(String) null})));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(new String[] {(String) null})));
         assertEquals("null", $.toJson((Collection) null));
         class Test {
             public String toString() {
                 return "test";
             }
         }
-        assertEquals("[[test,test]]",
+        assertEquals("[\n  [\n    test,\n    test\n  ]\n]",
             $.toJson(new ArrayList<Test[]>() { { add(new Test[] {new Test(), new Test()}); } }));
     }
 
@@ -465,191 +471,191 @@ _.repeat('abc', 0);
 
     @Test
     public void testByteArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((byte[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new byte[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new byte[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new byte[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testShortArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((short[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new short[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new short[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new short[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testIntArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((int[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new int[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new int[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new int[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testLongArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((long[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new long[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new long[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new long[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testFloatArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((float[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new float[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new float[] { 12.8f }, builder);
-        assertEquals("[12.8]", builder.toString());
+        assertEquals("[\n  12.8\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new float[] { -7.1f, 22.234f, 86.7f, -99.02f }, builder);
-        assertEquals("[-7.1,22.234,86.7,-99.02]", builder.toString());
+        assertEquals("[\n  -7.1,\n  22.234,\n  86.7,\n  -99.02\n]", builder.toString());
     }
 
     @Test
     public void testDoubleArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((double[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new double[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new double[] { 12.8 }, builder);
-        assertEquals("[12.8]", builder.toString());
+        assertEquals("[\n  12.8\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new double[] { -7.1, 22.234, 86.7, -99.02 }, builder);
-        assertEquals("[-7.1,22.234,86.7,-99.02]", builder.toString());
+        assertEquals("[\n  -7.1,\n  22.234,\n  86.7,\n  -99.02\n]", builder.toString());
     }
 
     @Test
     public void testBooleanArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((boolean[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new boolean[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new boolean[] { true }, builder);
-        assertEquals("[true]", builder.toString());
+        assertEquals("[\n  true\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new boolean[] { true, false, true }, builder);
-        assertEquals("[true,false,true]", builder.toString());
+        assertEquals("[\n  true,\n  false,\n  true\n]", builder.toString());
     }
 
     @Test
     public void testCharArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((char[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new char[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new char[] { 'a' }, builder);
-        assertEquals("[\"a\"]", builder.toString());
+        assertEquals("[\n  \"a\"\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new char[] { 'a', 'b', 'c' }, builder);
-        assertEquals("[\"a\",\"b\",\"c\"]", builder.toString());
+        assertEquals("[\n  \"a\",\n  \"b\",\n  \"c\"\n]", builder.toString());
     }
 
     @Test
     public void testObjectArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((Object[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new Object[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new Object[] { "Hello" }, builder);
-        assertEquals("[\"Hello\"]", builder.toString());
+        assertEquals("[\n  \"Hello\"\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new Object[] { "Hello", new Integer(12), new int[] { 1, 2, 3} }, builder);
-        assertEquals("[\"Hello\",12,[1,2,3]]", builder.toString());
+        assertEquals("[\n  \"Hello\",\n  12,\n  [\n    1,\n    2,\n    3\n  ]\n]", builder.toString());
     }
 
     @Test
@@ -658,13 +664,13 @@ _.repeat('abc', 0);
         testList.add("First item");
         testList.add("Second item");
 
-        assertEquals("[\"First item\",\"Second item\"]", $.toJson(testList));
-        assertEquals("[\"First item\",\"Second item\"]", new $(testList).toJson());
-        assertEquals("[\"First item\",\"Second item\"]", $.chain(testList).toJson().item());
-        assertEquals("[null]", $.toJson(Arrays.asList(Double.NaN)));
-        assertEquals("[null]", $.toJson(Arrays.asList(Double.POSITIVE_INFINITY)));
-        assertEquals("[null]", $.toJson(Arrays.asList(Float.NaN)));
-        assertEquals("[null]", $.toJson(Arrays.asList(Float.POSITIVE_INFINITY)));
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]", $.toJson(testList));
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]", new $(testList).toJson());
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]", $.chain(testList).toJson().item());
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Double.NaN)));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Double.POSITIVE_INFINITY)));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Float.NaN)));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Float.POSITIVE_INFINITY)));
     }
 
     @Test
@@ -673,44 +679,64 @@ _.repeat('abc', 0);
         testMap.put("First item", "1");
         testMap.put("Second item", "2");
 
-        assertEquals("{\"First item\":\"1\",\"Second item\":\"2\"}", $.toJson(testMap));
+        assertEquals("{\n  \"First item\": \"1\",\n  \"Second item\": \"2\"\n}", $.toJson(testMap));
         assertEquals("null", $.toJson((Map) null));
     }
 
     @Test
-    public void testDecode() {
-        String string = "[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]";
-        assertEquals("[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]",
+    public void toJsonFromMapFormatted() {
+        String string =
+        "{\n  \"glossary\": {\n    \"title\": \"example glossary\",\n    \"GlossDiv\": {\n      \"title\":"
+        + " \"S\",\n      \"GlossList\": {\n        \"GlossEntry\": {\n          \"ID\": \"SGML\",\n"
+        + "          \"SortAs\": \"SGML\",\n          \"GlossTerm\": \"Standard Generalized Markup Language\",\n"
+        + "          \"Acronym\": \"SGML\",\n          \"Abbrev\": \"ISO 8879:1986\",\n          \"GlossDef\": {\n"
+        + "            \"para\": \"A meta-markup language, used to create markup languages such as DocBook.\",\n"
+        + "            \"GlossSeeAlso\": [\n              \"GML\",\n              \"XML\"\n            ]\n"
+        + "          },\n          \"GlossSee\": \"markup\"\n        }\n      }\n    }\n  }\n}";
+        assertEquals(string, $.toJson((Map<String, Object>) $.fromJson(string)));
+    }
+
+    @Test
+        public void testDecode() {
+            String string = "[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]";
+        assertEquals("[\n  0,\n  {\n    \"1\": {\n      \"2\": {\n        \"3\": {\n          \"4\": [\n"
+        + "            5,\n            {\n              \"6\": 7\n            }\n          ]\n"
+        + "        }\n      }\n    }\n  }\n]",
             $.toJson((List<Object>) $.fromJson(string)));
-        assertEquals("[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]",
+        assertEquals("[\n  0,\n  {\n    \"1\": {\n      \"2\": {\n        \"3\": {\n          \"4\": [\n"
+        + "            5,\n            {\n              \"6\": 7\n            }\n          ]\n"
+        + "        }\n      }\n    }\n  }\n]",
             $.toJson((List<Object>) new $(string).fromJson()));
-        assertEquals("[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]",
+        assertEquals("[\n  0,\n  {\n    \"1\": {\n      \"2\": {\n        \"3\": {\n          \"4\": [\n"
+        + "            5,\n            {\n              \"6\": 7\n            }\n          ]\n"
+        + "        }\n      }\n    }\n  }\n]",
             $.toJson((List<Object>) $.chain(string).fromJson().value()));
     }
 
     @Test
     public void testDecode2() {
         String string = "[\"hello\\bworld\\\"abc\\tdef\\\\ghi\\rjkl\\n123\\f356\"]";
-        assertEquals("[\"hello\\bworld\\\"abc\\tdef\\\\ghi\\rjkl\\n123\\f356\"]",
+        assertEquals("[\n  \"hello\\bworld\\\"abc\\tdef\\\\ghi\\rjkl\\n123\\f356\"\n]",
             $.toJson((List<Object>) $.fromJson(string)));
     }
 
     @Test
     public void testDecode3() {
-        assertEquals("[]", $.toJson((List<Object>) $.fromJson("[]")));
+        assertEquals("[\n\n]", $.toJson((List<Object>) $.fromJson("[]")));
     }
 
     @Test
     public void testDecodeMap() {
         String string = "{\"first\": 123e+10,\"second\":[{\"k1\":{\"id\":\"id1\"}},"
             + "4,5,6,{\"id\":-123E-1}],\t\n\r \"third\":789,\"id\":null}";
-        assertEquals("{\"first\":1.23E12,\"second\":[{\"k1\":{\"id\":\"id1\"}},"
-            + "4,5,6,{\"id\":-12.3}],\"third\":789,\"id\":null}", $.toJson((Map<String, Object>) $.fromJson(string)));
+        assertEquals("{\n  \"first\": 1.23E12,\n  \"second\": [\n    {\n      \"k1\": {\n        \"id\": \"id1\"\n"
+        + "      }\n    },\n    4,\n    5,\n    6,\n    {\n      \"id\": -12.3\n    }\n  ],\n  \"third\": 789,\n"
+        + "  \"id\": null\n}", $.toJson((Map<String, Object>) $.fromJson(string)));
     }
 
     @Test
     public void testDecodeMap2() {
-        assertEquals("{}", $.toJson((Map<String, Object>) $.fromJson("{}")));
+        assertEquals("{\n\n}", $.toJson((Map<String, Object>) $.fromJson("{}")));
     }
 
     @Test
@@ -721,15 +747,16 @@ _.repeat('abc', 0);
         array1.add(new Double(222.123));
         array1.add(Boolean.TRUE);
         array1.add(Boolean.FALSE);
-        assertEquals("[\"abc\\u0010a\\/\",123,222.123,true,false]", $.toJson(array1));
-        String string = "[\"abc\\u0010a\\/\",123,222.123,true,false]";
-        assertEquals("[\"abc\\u0010a\\/\",123,222.123,true,false]", $.toJson((List<Object>) $.fromJson(string)));
+        assertEquals("[\n  \"abc\\u0010a\\/\",\n  123,\n  222.123,\n  true,\n  false\n]", $.toJson(array1));
+        String string = "[\n  \"abc\\u0010a\\/\",\n  123,\n  222.123,\n  true,\n  false\n]";
+        assertEquals("[\n  \"abc\\u0010a\\/\",\n  123,\n  222.123,\n  true,\n  false\n]",
+            $.toJson((List<Object>) $.fromJson(string)));
     }
 
     @Test
     public void testDecodeUnicode() {
-        assertEquals("[\"abc\u0A00\"]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0a00\"]")));
-        assertEquals("[\"abc\u0A00\"]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0A00\"]")));
+        assertEquals("[\n  \"abc\u0A00\"\n]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0a00\"]")));
+        assertEquals("[\n  \"abc\u0A00\"\n]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0A00\"]")));
     }
 
     @Test(expected = $.ParseException.class)
@@ -832,5 +859,82 @@ _.repeat('abc', 0);
         $.chain(new ArrayList<String>());
         $.chain(new HashSet<String>());
         $.chain(new String[] {});
+    }
+
+    @Test
+    public void chain() {
+        $.chain(new String[] {""}).first();
+        $.chain(new String[] {""}).first(1);
+        $.chain(new String[] {""}).initial();
+        $.chain(new String[] {""}).initial(1);
+        $.chain(new String[] {""}).last();
+        $.chain(new String[] {""}).last(1);
+        $.chain(new String[] {""}).rest();
+        $.chain(new String[] {""}).rest(1);
+        $.chain(new String[] {""}).flatten();
+        $.chain(new Integer[] {0}).map(new Function1<Integer, Integer>() {
+            public Integer apply(Integer value) { return value; } });
+        $.chain(new String[] {""}).filter(new Predicate<String>() {
+            public Boolean apply(String str) { return true; } });
+        $.chain(new String[] {""}).reject(new Predicate<String>() {
+            public Boolean apply(String str) { return true; } });
+        $.chain(new String[] {""}).reduce(new FunctionAccum<String, String>() {
+            public String apply(String accum, String str) { return null; } }, "");
+        $.chain(new String[] {""}).reduceRight(new FunctionAccum<String, String>() {
+            public String apply(String accum, String str) { return null; } }, "");
+        $.chain(new String[] {""}).find(new Predicate<String>() {
+            public Boolean apply(String str) { return true; } });
+        $.chain(new String[] {""}).findLast(new Predicate<String>() {
+            public Boolean apply(String str) { return true; } });
+        $.chain(new Integer[] {0}).max();
+        $.chain(new Integer[] {0}).max(new Function1<Integer, Integer>() {
+            public Integer apply(Integer value) { return value; } });
+        $.chain(new Integer[] {0}).min();
+        $.chain(new Integer[] {0}).min(new Function1<Integer, Integer>() {
+            public Integer apply(Integer value) { return value; } });
+        $.chain(new Integer[] {0}).sort();
+        $.chain(new Integer[] {0}).sortBy(new Function1<Integer, Integer>() {
+            public Integer apply(Integer value) { return value; } });
+        $.chain(new LinkedHashMap<Integer, Integer>().entrySet()).sortBy("");
+        $.chain(new Integer[] {0}).groupBy(new Function1<Integer, Integer>() {
+            public Integer apply(Integer value) { return value; } });
+        $.chain(new Integer[] {0}).indexBy("");
+        $.chain(new Integer[] {0}).countBy(new Function1<Integer, Integer>() {
+            public Integer apply(Integer value) { return value; } });
+        $.chain(new Integer[] {0}).shuffle();
+        $.chain(new Integer[] {0}).sample();
+        $.chain(new Integer[] {0}).sample(1);
+        $.chain(new String[] {""}).tap(new Block<String>() {
+            public void apply(String str) {
+            } });
+        $.chain(new String[] {""}).every(new Predicate<String>() {
+            public Boolean apply(String str) { return true; } });
+        $.chain(new String[] {""}).some(new Predicate<String>() {
+            public Boolean apply(String str) { return true; } });
+        $.chain(new String[] {""}).contains("");
+        $.chain(new String[] {""}).invoke("toString", Collections.emptyList());
+        $.chain(new String[] {""}).invoke("toString");
+        $.chain(new String[] {""}).pluck("toString");
+        $.chain(new String[] {""}).where(Collections.emptyList());
+        $.chain(new String[] {""}).findWhere(Collections.emptyList());
+        $.chain(new Integer[] {0}).uniq();
+        $.chain(new Integer[] {0}).uniq(new Function1<Integer, Integer>() {
+            public Integer apply(Integer value) { return value; } });
+        $.chain(new String[] {""}).union();
+        $.chain(new String[] {""}).intersection();
+        $.chain(new String[] {""}).difference();
+        $.chain(new String[] {""}).range(0);
+        $.chain(new String[] {""}).range(0, 0);
+        $.chain(new String[] {""}).range(0, 0, 1);
+        $.chain(new String[] {""}).chunk(1);
+        $.chain(new String[] {""}).concat();
+        $.chain(new String[] {""}).slice(0);
+        $.chain(new String[] {""}).slice(0, 0);
+        $.chain(new String[] {""}).reverse();
+        $.chain(new String[] {""}).join();
+        $.chain(new String[] {""}).join("");
+        $.chain(new String[] {""}).skip(0);
+        $.chain(new String[] {""}).limit(0);
+        $.chain(new LinkedHashMap<Integer, Integer>().entrySet()).toMap();
     }
 }

--- a/string-plugin/src/main/java/com/github/underscore/string/$.java
+++ b/string-plugin/src/main/java/com/github/underscore/string/$.java
@@ -734,8 +734,74 @@ public class $<T> extends com.github.underscore.$<T> {
         return result + omission;
     }
 
+    public static class JsonStringBuilder {
+        private final StringBuilder builder;
+        private int ident;
+        private boolean newString;
+        private boolean newKey;
+        private boolean newLine;
+
+        public JsonStringBuilder() {
+            builder = new StringBuilder();
+        }
+
+        public JsonStringBuilder append(final char character) {
+            switch (character) {
+                case '[':
+                case '{':
+                    fillSpaces(newLine);
+                    ident += 2;
+                    break;
+                case ']':
+                case '}':
+                    ident -= 2;
+                    builder.append("\n");
+                    fillSpaces(true);
+                    break;
+                case '\"':
+                    newString = !newString;
+                    fillSpaces(newString && !newKey);
+                    break;
+                default:
+                    break;
+            }
+            builder.append(character);
+            if (character == ',' || character == '[' || character == '{') {
+                builder.append("\n");
+                newLine = true;
+            } else {
+                newLine = false;
+            }
+            if (character == ':') {
+                builder.append(' ');
+                newKey = true;
+            } else {
+                newKey = false;
+            }
+            return this;
+        }
+
+        public JsonStringBuilder append(final String string) {
+            fillSpaces(!newString && !newKey);
+            builder.append(string);
+            return this;
+        }
+
+        private void fillSpaces(final boolean condition) {
+            if (condition) {
+                for (int index = 0; index < ident; index += 1) {
+                    builder.append(' ');
+                }
+            }
+        }
+
+        public String toString() {
+            return builder.toString();
+        }
+    }
+
     public static class JsonArray {
-        public static void writeJson(Collection collection, StringBuilder builder) {
+        public static void writeJson(Collection collection, JsonStringBuilder builder) {
             if (collection == null) {
                 builder.append(NULL);
                 return;
@@ -763,7 +829,7 @@ public class $<T> extends com.github.underscore.$<T> {
             builder.append(']');
         }
 
-        public static void writeJson(byte[] array, StringBuilder builder) {
+        public static void writeJson(byte[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -781,7 +847,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(short[] array, StringBuilder builder) {
+        public static void writeJson(short[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -799,7 +865,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(int[] array, StringBuilder builder) {
+        public static void writeJson(int[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -817,7 +883,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(long[] array, StringBuilder builder) {
+        public static void writeJson(long[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -835,7 +901,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(float[] array, StringBuilder builder) {
+        public static void writeJson(float[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -853,7 +919,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(double[] array, StringBuilder builder) {
+        public static void writeJson(double[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -871,7 +937,7 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(boolean[] array, StringBuilder builder) {
+        public static void writeJson(boolean[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -889,25 +955,25 @@ public class $<T> extends com.github.underscore.$<T> {
             }
         }
 
-        public static void writeJson(char[] array, StringBuilder builder) {
+        public static void writeJson(char[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
                 builder.append("[]");
             } else {
-                builder.append("[\"");
+                builder.append('[').append('\"');
                 builder.append(String.valueOf(array[0]));
 
                 for (int i = 1; i < array.length; i++) {
-                    builder.append("\",\"");
+                    builder.append('\"').append(',').append('\"');
                     builder.append(String.valueOf(array[i]));
                 }
 
-                builder.append("\"]");
+                builder.append('\"').append(']');
             }
         }
 
-        public static void writeJson(Object[] array, StringBuilder builder) {
+        public static void writeJson(Object[] array, JsonStringBuilder builder) {
             if (array == null) {
                 builder.append(NULL);
             } else if (array.length == 0) {
@@ -927,7 +993,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static class JsonObject {
-        public static void writeJson(Map map, StringBuilder builder) {
+        public static void writeJson(Map map, JsonStringBuilder builder) {
             if (map == null) {
                 builder.append(NULL);
                 return;
@@ -955,7 +1021,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static class JsonValue {
-        public static void writeJson(Object value, StringBuilder builder) {
+        public static void writeJson(Object value, JsonStringBuilder builder) {
             if (value == null) {
                 builder.append(NULL);
             } else if (value instanceof String) {
@@ -1061,7 +1127,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static String toJson(Collection collection) {
-        final StringBuilder builder = new StringBuilder();
+        final JsonStringBuilder builder = new JsonStringBuilder();
 
         JsonArray.writeJson(collection, builder);
         return builder.toString();
@@ -1072,7 +1138,7 @@ public class $<T> extends com.github.underscore.$<T> {
     }
 
     public static String toJson(Map map) {
-        final StringBuilder builder = new StringBuilder();
+        final JsonStringBuilder builder = new JsonStringBuilder();
 
         JsonObject.writeJson(map, builder);
         return builder.toString();

--- a/string-plugin/src/test/java/com/github/underscore/string/StringTest.java
+++ b/string-plugin/src/test/java/com/github/underscore/string/StringTest.java
@@ -27,6 +27,8 @@ import com.github.underscore.Block;
 import com.github.underscore.Function1;
 import com.github.underscore.FunctionAccum;
 import com.github.underscore.Predicate;
+import com.github.underscore.string.$.JsonStringBuilder;
+
 import java.util.*;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -394,53 +396,53 @@ _.repeat('abc', 0);
 
     @Test
     public void testJsonArray() {
-        StringBuilder builder = new StringBuilder();
+        JsonStringBuilder builder = new JsonStringBuilder();
         $.JsonArray.writeJson((Collection) null, builder);
         assertEquals("null", builder.toString());
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new ArrayList<String>() { { add((String) null); } }, builder);
-        assertEquals("[null]", builder.toString());
+        assertEquals("[\n  null\n]", builder.toString());
     }
 
     @Test
     public void testJsonArrayCollection() {
-        assertEquals("[\"First item\",\"Second item\"]",
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]",
             $.toJson(Arrays.asList("First item", "Second item")));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new byte[] {1, 2})));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new short[] {1, 2})));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new int[] {1, 2})));
-        assertEquals("[[1,2]]",
+        assertEquals("[\n  [\n    1,\n    2\n  ]\n]",
             $.toJson(Arrays.asList(new long[] {1, 2})));
-        assertEquals("[[1.0,2.0]]",
+        assertEquals("[\n  [\n    1.0,\n    2.0\n  ]\n]",
             $.toJson(Arrays.asList(new float[] {1, 2})));
-        assertEquals("[[1.0,2.0]]",
+        assertEquals("[\n  [\n    1.0,\n    2.0\n  ]\n]",
             $.toJson(Arrays.asList(new double[] {1, 2})));
-        assertEquals("[[\"1\",\"2\"]]",
+        assertEquals("[\n  [\n    \"1\",\n    \"2\"\n  ]\n]",
             $.toJson(Arrays.asList(new char[] {'1', '2'})));
-        assertEquals("[[true,false,true]]",
+        assertEquals("[\n  [\n    true,\n    false,\n    true\n  ]\n]",
             $.toJson(Arrays.asList(new boolean[] {true, false, true})));
-        assertEquals("[1.0,2.0]",
+        assertEquals("[\n  1.0,\n  2.0\n]",
             $.toJson(Arrays.asList(new Float[] {1F, 2F})));
-        assertEquals("[1.0,2.0]",
+        assertEquals("[\n  1.0,\n  2.0\n]",
             $.toJson(Arrays.asList(new Double[] {1D, 2D})));
-        assertEquals("[true,false,true]",
+        assertEquals("[\n  true,\n  false,\n  true\n]",
             $.toJson(Arrays.asList(new Boolean[] {true, false, true})));
-        assertEquals("[[\"First item\",\"Second item\"]]",
+        assertEquals("[\n  [\n    \"First item\",\n    \"Second item\"\n  ]\n]",
             $.toJson(Arrays.asList(Arrays.asList("First item", "Second item"))));
-        assertEquals("[{\"1\":\"First item\",\"2\":\"Second item\",\"3\":null}]",
+        assertEquals("[\n  {\n    \"1\": \"First item\",\n    \"2\": \"Second item\",\n    \"3\": null\n  }\n]",
             $.toJson(Arrays.asList(new LinkedHashMap() { {
                 put("1", "First item"); put("2", "Second item"); put("3", null); } })));
-        assertEquals("[null]", $.toJson(Arrays.asList(new String[] {(String) null})));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(new String[] {(String) null})));
         assertEquals("null", $.toJson((Collection) null));
         class Test {
             public String toString() {
                 return "test";
             }
         }
-        assertEquals("[[test,test]]",
+        assertEquals("[\n  [\n    test,\n    test\n  ]\n]",
             $.toJson(new ArrayList<Test[]>() { { add(new Test[] {new Test(), new Test()}); } }));
     }
 
@@ -469,191 +471,191 @@ _.repeat('abc', 0);
 
     @Test
     public void testByteArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((byte[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new byte[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new byte[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new byte[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testShortArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((short[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new short[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new short[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new short[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testIntArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((int[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new int[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new int[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new int[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testLongArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((long[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new long[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new long[] { 12 }, builder);
-        assertEquals("[12]", builder.toString());
+        assertEquals("[\n  12\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new long[] { -7, 22, 86, -99 }, builder);
-        assertEquals("[-7,22,86,-99]", builder.toString());
+        assertEquals("[\n  -7,\n  22,\n  86,\n  -99\n]", builder.toString());
     }
 
     @Test
     public void testFloatArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((float[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new float[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new float[] { 12.8f }, builder);
-        assertEquals("[12.8]", builder.toString());
+        assertEquals("[\n  12.8\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new float[] { -7.1f, 22.234f, 86.7f, -99.02f }, builder);
-        assertEquals("[-7.1,22.234,86.7,-99.02]", builder.toString());
+        assertEquals("[\n  -7.1,\n  22.234,\n  86.7,\n  -99.02\n]", builder.toString());
     }
 
     @Test
     public void testDoubleArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((double[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new double[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new double[] { 12.8 }, builder);
-        assertEquals("[12.8]", builder.toString());
+        assertEquals("[\n  12.8\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new double[] { -7.1, 22.234, 86.7, -99.02 }, builder);
-        assertEquals("[-7.1,22.234,86.7,-99.02]", builder.toString());
+        assertEquals("[\n  -7.1,\n  22.234,\n  86.7,\n  -99.02\n]", builder.toString());
     }
 
     @Test
     public void testBooleanArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((boolean[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new boolean[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new boolean[] { true }, builder);
-        assertEquals("[true]", builder.toString());
+        assertEquals("[\n  true\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new boolean[] { true, false, true }, builder);
-        assertEquals("[true,false,true]", builder.toString());
+        assertEquals("[\n  true,\n  false,\n  true\n]", builder.toString());
     }
 
     @Test
     public void testCharArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((char[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new char[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new char[] { 'a' }, builder);
-        assertEquals("[\"a\"]", builder.toString());
+        assertEquals("[\n  \"a\"\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new char[] { 'a', 'b', 'c' }, builder);
-        assertEquals("[\"a\",\"b\",\"c\"]", builder.toString());
+        assertEquals("[\n  \"a\",\n  \"b\",\n  \"c\"\n]", builder.toString());
     }
 
     @Test
     public void testObjectArrayToString() {
-        StringBuilder builder;
+        JsonStringBuilder builder;
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson((Object[]) null, builder);
         assertEquals("null", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new Object[0], builder);
         assertEquals("[]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new Object[] { "Hello" }, builder);
-        assertEquals("[\"Hello\"]", builder.toString());
+        assertEquals("[\n  \"Hello\"\n]", builder.toString());
 
-        builder = new StringBuilder();
+        builder = new JsonStringBuilder();
         $.JsonArray.writeJson(new Object[] { "Hello", new Integer(12), new int[] { 1, 2, 3} }, builder);
-        assertEquals("[\"Hello\",12,[1,2,3]]", builder.toString());
+        assertEquals("[\n  \"Hello\",\n  12,\n  [\n    1,\n    2,\n    3\n  ]\n]", builder.toString());
     }
 
     @Test
@@ -662,13 +664,13 @@ _.repeat('abc', 0);
         testList.add("First item");
         testList.add("Second item");
 
-        assertEquals("[\"First item\",\"Second item\"]", $.toJson(testList));
-        assertEquals("[\"First item\",\"Second item\"]", new $(testList).toJson());
-        assertEquals("[\"First item\",\"Second item\"]", $.chain(testList).toJson().item());
-        assertEquals("[null]", $.toJson(Arrays.asList(Double.NaN)));
-        assertEquals("[null]", $.toJson(Arrays.asList(Double.POSITIVE_INFINITY)));
-        assertEquals("[null]", $.toJson(Arrays.asList(Float.NaN)));
-        assertEquals("[null]", $.toJson(Arrays.asList(Float.POSITIVE_INFINITY)));
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]", $.toJson(testList));
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]", new $(testList).toJson());
+        assertEquals("[\n  \"First item\",\n  \"Second item\"\n]", $.chain(testList).toJson().item());
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Double.NaN)));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Double.POSITIVE_INFINITY)));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Float.NaN)));
+        assertEquals("[\n  null\n]", $.toJson(Arrays.asList(Float.POSITIVE_INFINITY)));
     }
 
     @Test
@@ -677,44 +679,64 @@ _.repeat('abc', 0);
         testMap.put("First item", "1");
         testMap.put("Second item", "2");
 
-        assertEquals("{\"First item\":\"1\",\"Second item\":\"2\"}", $.toJson(testMap));
+        assertEquals("{\n  \"First item\": \"1\",\n  \"Second item\": \"2\"\n}", $.toJson(testMap));
         assertEquals("null", $.toJson((Map) null));
     }
 
     @Test
-    public void testDecode() {
-        String string = "[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]";
-        assertEquals("[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]",
+    public void toJsonFromMapFormatted() {
+        String string =
+        "{\n  \"glossary\": {\n    \"title\": \"example glossary\",\n    \"GlossDiv\": {\n      \"title\":"
+        + " \"S\",\n      \"GlossList\": {\n        \"GlossEntry\": {\n          \"ID\": \"SGML\",\n"
+        + "          \"SortAs\": \"SGML\",\n          \"GlossTerm\": \"Standard Generalized Markup Language\",\n"
+        + "          \"Acronym\": \"SGML\",\n          \"Abbrev\": \"ISO 8879:1986\",\n          \"GlossDef\": {\n"
+        + "            \"para\": \"A meta-markup language, used to create markup languages such as DocBook.\",\n"
+        + "            \"GlossSeeAlso\": [\n              \"GML\",\n              \"XML\"\n            ]\n"
+        + "          },\n          \"GlossSee\": \"markup\"\n        }\n      }\n    }\n  }\n}";
+        assertEquals(string, $.toJson((Map<String, Object>) $.fromJson(string)));
+    }
+
+    @Test
+        public void testDecode() {
+            String string = "[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]";
+        assertEquals("[\n  0,\n  {\n    \"1\": {\n      \"2\": {\n        \"3\": {\n          \"4\": [\n"
+        + "            5,\n            {\n              \"6\": 7\n            }\n          ]\n"
+        + "        }\n      }\n    }\n  }\n]",
             $.toJson((List<Object>) $.fromJson(string)));
-        assertEquals("[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]",
+        assertEquals("[\n  0,\n  {\n    \"1\": {\n      \"2\": {\n        \"3\": {\n          \"4\": [\n"
+        + "            5,\n            {\n              \"6\": 7\n            }\n          ]\n"
+        + "        }\n      }\n    }\n  }\n]",
             $.toJson((List<Object>) new $(string).fromJson()));
-        assertEquals("[0,{\"1\":{\"2\":{\"3\":{\"4\":[5,{\"6\":7}]}}}}]",
+        assertEquals("[\n  0,\n  {\n    \"1\": {\n      \"2\": {\n        \"3\": {\n          \"4\": [\n"
+        + "            5,\n            {\n              \"6\": 7\n            }\n          ]\n"
+        + "        }\n      }\n    }\n  }\n]",
             $.toJson((List<Object>) $.chain(string).fromJson().value()));
     }
 
     @Test
     public void testDecode2() {
         String string = "[\"hello\\bworld\\\"abc\\tdef\\\\ghi\\rjkl\\n123\\f356\"]";
-        assertEquals("[\"hello\\bworld\\\"abc\\tdef\\\\ghi\\rjkl\\n123\\f356\"]",
+        assertEquals("[\n  \"hello\\bworld\\\"abc\\tdef\\\\ghi\\rjkl\\n123\\f356\"\n]",
             $.toJson((List<Object>) $.fromJson(string)));
     }
 
     @Test
     public void testDecode3() {
-        assertEquals("[]", $.toJson((List<Object>) $.fromJson("[]")));
+        assertEquals("[\n\n]", $.toJson((List<Object>) $.fromJson("[]")));
     }
 
     @Test
     public void testDecodeMap() {
         String string = "{\"first\": 123e+10,\"second\":[{\"k1\":{\"id\":\"id1\"}},"
             + "4,5,6,{\"id\":-123E-1}],\t\n\r \"third\":789,\"id\":null}";
-        assertEquals("{\"first\":1.23E12,\"second\":[{\"k1\":{\"id\":\"id1\"}},"
-            + "4,5,6,{\"id\":-12.3}],\"third\":789,\"id\":null}", $.toJson((Map<String, Object>) $.fromJson(string)));
+        assertEquals("{\n  \"first\": 1.23E12,\n  \"second\": [\n    {\n      \"k1\": {\n        \"id\": \"id1\"\n"
+        + "      }\n    },\n    4,\n    5,\n    6,\n    {\n      \"id\": -12.3\n    }\n  ],\n  \"third\": 789,\n"
+        + "  \"id\": null\n}", $.toJson((Map<String, Object>) $.fromJson(string)));
     }
 
     @Test
     public void testDecodeMap2() {
-        assertEquals("{}", $.toJson((Map<String, Object>) $.fromJson("{}")));
+        assertEquals("{\n\n}", $.toJson((Map<String, Object>) $.fromJson("{}")));
     }
 
     @Test
@@ -725,15 +747,16 @@ _.repeat('abc', 0);
         array1.add(new Double(222.123));
         array1.add(Boolean.TRUE);
         array1.add(Boolean.FALSE);
-        assertEquals("[\"abc\\u0010a\\/\",123,222.123,true,false]", $.toJson(array1));
-        String string = "[\"abc\\u0010a\\/\",123,222.123,true,false]";
-        assertEquals("[\"abc\\u0010a\\/\",123,222.123,true,false]", $.toJson((List<Object>) $.fromJson(string)));
+        assertEquals("[\n  \"abc\\u0010a\\/\",\n  123,\n  222.123,\n  true,\n  false\n]", $.toJson(array1));
+        String string = "[\n  \"abc\\u0010a\\/\",\n  123,\n  222.123,\n  true,\n  false\n]";
+        assertEquals("[\n  \"abc\\u0010a\\/\",\n  123,\n  222.123,\n  true,\n  false\n]",
+            $.toJson((List<Object>) $.fromJson(string)));
     }
 
     @Test
     public void testDecodeUnicode() {
-        assertEquals("[\"abc\u0A00\"]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0a00\"]")));
-        assertEquals("[\"abc\u0A00\"]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0A00\"]")));
+        assertEquals("[\n  \"abc\u0A00\"\n]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0a00\"]")));
+        assertEquals("[\n  \"abc\u0A00\"\n]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0A00\"]")));
     }
 
     @Test(expected = $.ParseException.class)


### PR DESCRIPTION
Example formatted json:

```
{
  "glossary": {
    "title": "example glossary",
    "GlossDiv": {
      "title": "S",
      "GlossList": {
        "GlossEntry": {
          "ID": "SGML",
          "SortAs": "SGML",
          "GlossTerm": "Standard Generalized Markup Language",
          "Acronym": "SGML",
          "Abbrev": "ISO 8879:1986",
          "GlossDef": {
            "para": "A meta-markup language, used to create markup languages such as DocBook.",
            "GlossSeeAlso": [
              "GML",
              "XML"
            ]
          },
          "GlossSee": "markup"
        }
      }
    }
  }
}
```