### PR TITLE
Fix unicode parser in string and lodash plugins.

### DIFF
--- a/lodash-plugin/src/main/java/com/github/underscore/lodash/$.java
+++ b/lodash-plugin/src/main/java/com/github/underscore/lodash/$.java
@@ -1799,14 +1799,20 @@ public class $<T> extends com.github.underscore.$<T> {
                 break;
             case 'u':
                 char[] hexChars = new char[4];
+                boolean isHexCharsDigits = true;
                 for (int i = 0; i < 4; i++) {
                     read();
                     if (!isHexDigit()) {
-                        throw expected("hexadecimal digit");
+                        isHexCharsDigits = false;
                     }
                     hexChars[i] = (char) current;
                 }
-                captureBuffer.append((char) Integer.parseInt(new String(hexChars), 16));
+                if (isHexCharsDigits) {
+                    captureBuffer.append((char) Integer.parseInt(new String(hexChars), 16));
+                } else {
+                    captureBuffer.append("\\u").append(hexChars[0]).append(hexChars[1]).append(hexChars[2])
+                        .append(hexChars[3]);
+                }
                 break;
             default:
                 throw expected("valid escape sequence");

--- a/lodash-plugin/src/test/java/com/github/underscore/lodash/StringTest.java
+++ b/lodash-plugin/src/test/java/com/github/underscore/lodash/StringTest.java
@@ -770,17 +770,28 @@ _.repeat('abc', 0);
         assertEquals("[\n  \"abc\u0A00\"\n]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0A00\"]")));
     }
 
-    @Test(expected = $.ParseException.class)
-    public void testDecodeUnicodeErr1() {
-        try {
-            $.fromJson("[\"abc\\u0$00\"]");
-            fail("Expected ParseException");
-        } catch ($.ParseException ex) {
-            ex.getOffset();
-            ex.getLine();
-            ex.getColumn();
-            throw ex;
-        }
+    @Test
+    public void testDecodeSpecialCharacter() {
+        assertEquals("{\n  \"description\": \"c:\\\\userDescription.txt\"\n}", $.toJson(
+            (Map<String, Object>) $.fromJson("{\"description\":\"c:\\userDescription.txt\"}")));
+        assertEquals("{description=c:\\userDescription.txt}", $.fromJson(
+            $.toJson(new LinkedHashMap<String, String>() { {
+                put("description",  "c:\\userDescription.txt"); } })).toString());
+    }
+
+    @Test
+    public void testDecodeUnicode1() {
+        assertEquals("[abc\\u0$00]", $.fromJson("[\"abc\\u0$00\"]").toString());
+    }
+
+    @Test
+    public void testDecodeUnicode2() {
+        assertEquals("[abc\\u001g/]", $.fromJson("[\"abc\\u001g\\/\"]").toString());
+    }
+
+    @Test
+    public void testDecodeUnicode3() {
+        assertEquals("[abc\\u001G/]", $.fromJson("[\"abc\\u001G\\/\"]").toString());
     }
 
     @Test(expected = $.ParseException.class)
@@ -814,11 +825,6 @@ _.repeat('abc', 0);
     }
 
     @Test(expected = $.ParseException.class)
-    public void testDecodeParseErr7() {
-        $.fromJson("[\"abc\\u001g\\/\"]");
-    }
-
-    @Test(expected = $.ParseException.class)
     public void testDecodeParseErr8() {
         $.fromJson("[\"\\abc\"]");
     }
@@ -830,7 +836,15 @@ _.repeat('abc', 0);
 
     @Test(expected = $.ParseException.class)
     public void testDecodeParseErr10() {
-        $.fromJson("[123.a]");
+        try {
+            $.fromJson("[123.a]");
+            fail("Expected ParseException");
+        } catch ($.ParseException ex) {
+            ex.getOffset();
+            ex.getLine();
+            ex.getColumn();
+            throw ex;
+        }
     }
 
     @Test(expected = $.ParseException.class)
@@ -851,11 +865,6 @@ _.repeat('abc', 0);
     @Test(expected = $.ParseException.class)
     public void testDecodeParseErr14() {
         $.fromJson("[\"abc\"][]");
-    }
-
-    @Test(expected = $.ParseException.class)
-    public void testDecodeParseErr15() {
-        $.fromJson("[\"abc\\u001G\\/\"]");
     }
 
     @SuppressWarnings("unchecked")

--- a/string-plugin/src/main/java/com/github/underscore/string/$.java
+++ b/string-plugin/src/main/java/com/github/underscore/string/$.java
@@ -1356,14 +1356,20 @@ public class $<T> extends com.github.underscore.$<T> {
                 break;
             case 'u':
                 char[] hexChars = new char[4];
+                boolean isHexCharsDigits = true;
                 for (int i = 0; i < 4; i++) {
                     read();
                     if (!isHexDigit()) {
-                        throw expected("hexadecimal digit");
+                        isHexCharsDigits = false;
                     }
                     hexChars[i] = (char) current;
                 }
-                captureBuffer.append((char) Integer.parseInt(new String(hexChars), 16));
+                if (isHexCharsDigits) {
+                    captureBuffer.append((char) Integer.parseInt(new String(hexChars), 16));
+                } else {
+                    captureBuffer.append("\\u").append(hexChars[0]).append(hexChars[1]).append(hexChars[2])
+                        .append(hexChars[3]);
+                }
                 break;
             default:
                 throw expected("valid escape sequence");

--- a/string-plugin/src/test/java/com/github/underscore/string/StringTest.java
+++ b/string-plugin/src/test/java/com/github/underscore/string/StringTest.java
@@ -770,17 +770,28 @@ _.repeat('abc', 0);
         assertEquals("[\n  \"abc\u0A00\"\n]", $.toJson((List<Object>) $.fromJson("[\"abc\\u0A00\"]")));
     }
 
-    @Test(expected = $.ParseException.class)
-    public void testDecodeUnicodeErr1() {
-        try {
-            $.fromJson("[\"abc\\u0$00\"]");
-            fail("Expected ParseException");
-        } catch ($.ParseException ex) {
-            ex.getOffset();
-            ex.getLine();
-            ex.getColumn();
-            throw ex;
-        }
+    @Test
+    public void testDecodeSpecialCharacter() {
+        assertEquals("{\n  \"description\": \"c:\\\\userDescription.txt\"\n}", $.toJson(
+            (Map<String, Object>) $.fromJson("{\"description\":\"c:\\userDescription.txt\"}")));
+        assertEquals("{description=c:\\userDescription.txt}", $.fromJson(
+            $.toJson(new LinkedHashMap<String, String>() { {
+                put("description",  "c:\\userDescription.txt"); } })).toString());
+    }
+
+    @Test
+    public void testDecodeUnicode1() {
+        assertEquals("[abc\\u0$00]", $.fromJson("[\"abc\\u0$00\"]").toString());
+    }
+
+    @Test
+    public void testDecodeUnicode2() {
+        assertEquals("[abc\\u001g/]", $.fromJson("[\"abc\\u001g\\/\"]").toString());
+    }
+
+    @Test
+    public void testDecodeUnicode3() {
+        assertEquals("[abc\\u001G/]", $.fromJson("[\"abc\\u001G\\/\"]").toString());
     }
 
     @Test(expected = $.ParseException.class)
@@ -814,11 +825,6 @@ _.repeat('abc', 0);
     }
 
     @Test(expected = $.ParseException.class)
-    public void testDecodeParseErr7() {
-        $.fromJson("[\"abc\\u001g\\/\"]");
-    }
-
-    @Test(expected = $.ParseException.class)
     public void testDecodeParseErr8() {
         $.fromJson("[\"\\abc\"]");
     }
@@ -830,7 +836,15 @@ _.repeat('abc', 0);
 
     @Test(expected = $.ParseException.class)
     public void testDecodeParseErr10() {
-        $.fromJson("[123.a]");
+        try {
+            $.fromJson("[123.a]");
+            fail("Expected ParseException");
+        } catch ($.ParseException ex) {
+            ex.getOffset();
+            ex.getLine();
+            ex.getColumn();
+            throw ex;
+        }
     }
 
     @Test(expected = $.ParseException.class)
@@ -851,11 +865,6 @@ _.repeat('abc', 0);
     @Test(expected = $.ParseException.class)
     public void testDecodeParseErr14() {
         $.fromJson("[\"abc\"][]");
-    }
-
-    @Test(expected = $.ParseException.class)
-    public void testDecodeParseErr15() {
-        $.fromJson("[\"abc\\u001G\\/\"]");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
It fixes string parser `{"description": "c:\userDescription.txt"}`