### PR TITLE
Chain<T>.uniq(Function1<T, F>) should return Iterable<T>, not Iterable<F>.

### DIFF
--- a/lodash-plugin/src/main/java/com/github/underscore/lodash/$.java
+++ b/lodash-plugin/src/main/java/com/github/underscore/lodash/$.java
@@ -297,8 +297,8 @@ public class $<T> extends com.github.underscore.$<T> {
         }
 
         @SuppressWarnings("unchecked")
-        public <F> Chain<F> uniq(final Function1<T, F> func) {
-            return new Chain<F>($.newArrayList((Iterable<F>) $.uniq(value(), func)));
+        public <F> Chain<T> uniq(final Function1<T, F> func) {
+            return new Chain<T>($.newArrayList($.uniq(value(), func)));
         }
 
         public Chain<T> distinct() {

--- a/math-plugin/src/main/java/com/github/underscore/math/$.java
+++ b/math-plugin/src/main/java/com/github/underscore/math/$.java
@@ -251,8 +251,8 @@ public class $<T> extends com.github.underscore.$<T> {
         }
 
         @SuppressWarnings("unchecked")
-        public <F> Chain<F> uniq(final Function1<T, F> func) {
-            return new Chain<F>($.newArrayList((Iterable<F>) $.uniq(value(), func)));
+        public <F> Chain<T> uniq(final Function1<T, F> func) {
+            return new Chain<T>($.newArrayList($.uniq(value(), func)));
         }
 
         public Chain<T> distinct() {

--- a/src/main/java/com/github/underscore/$.java
+++ b/src/main/java/com/github/underscore/$.java
@@ -2079,8 +2079,8 @@ public class $<T> {
         }
 
         @SuppressWarnings("unchecked")
-        public <F> Chain<F> uniq(final Function1<T, F> func) {
-            return new Chain<F>($.newArrayList((Iterable<F>) $.uniq(list, func)));
+        public <F> Chain<T> uniq(final Function1<T, F> func) {
+            return new Chain<T>($.newArrayList($.uniq(list, func)));
         }
 
         public Chain<T> distinct() {

--- a/src/test/java/com/github/underscore/ArraysTest.java
+++ b/src/test/java/com/github/underscore/ArraysTest.java
@@ -475,7 +475,7 @@ _.uniq([1, 2, 1, 3, 1, 4]);
             }
         });
         assertEquals("[moe, 50, curly, 60]", resultObject.toString());
-        final List<String> resultObjectChain =
+        final List<Person> resultObjectChain =
         $.chain(asList(new Person("moe", 40), new Person("moe", 50), new Person("curly", 60))).uniq(
             new Function1<Person, String>() {
             public String apply(Person person) {

--- a/src/test/java/com/github/underscore/ChainingTest.java
+++ b/src/test/java/com/github/underscore/ChainingTest.java
@@ -417,13 +417,12 @@ var sum = _(words)
     @Test
     @SuppressWarnings("unchecked")
     public void chain8() {
-        final List<Comparable> result = $.chain($.chain($.class.getDeclaredMethods())
-            .reduce(new FunctionAccum<List<String>, Method>() {
-                public List<String> apply(final List<String> accum, final Method method) {
-                    accum.add(method.getName());
-                    return accum;
+        final List<Comparable> result = $.chain($.class.getDeclaredMethods())
+            .map(new Function1<Method, String>() {
+                public String apply(final Method method) {
+                    return method.getName();
                 }
-            }, new ArrayList<String>()).item())
+            })
             .reject(new Predicate<String>() {
                 public Boolean apply(final String name) {
                     return name.contains("$");

--- a/src/test/java/com/github/underscore/ChainingTest.java
+++ b/src/test/java/com/github/underscore/ChainingTest.java
@@ -415,6 +415,34 @@ var sum = _(words)
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void chain8() {
+        final List<Comparable> result = $.chain($.chain($.class.getDeclaredMethods())
+            .reduce(new FunctionAccum<List<String>, Method>() {
+                public List<String> apply(final List<String> accum, final Method method) {
+                    accum.add(method.getName());
+                    return accum;
+                }
+            }, new ArrayList<String>()).item())
+            .reject(new Predicate<String>() {
+                public Boolean apply(final String name) {
+                    return name.contains("$");
+                }
+            })
+            .uniq(new Function1<String, Character>() {
+                public Character apply(final String name) {
+                    // Contrived example to test that .uniq returns
+                    // a Chain<String> rather than a Chain<Character>.
+                    return name.charAt(0);
+                }
+            })
+            .sort()
+            .first(4)
+            .value();
+        assertEquals(4, result.size());
+    }
+
+    @Test
     public void chainToMap() {
         assertEquals("{name1=one, name2=two}", $.chain((new LinkedHashMap<String, String>() { {
             put("name1", "one");

--- a/string-plugin/src/main/java/com/github/underscore/string/$.java
+++ b/string-plugin/src/main/java/com/github/underscore/string/$.java
@@ -288,8 +288,8 @@ public class $<T> extends com.github.underscore.$<T> {
         }
 
         @SuppressWarnings("unchecked")
-        public <F> Chain<F> uniq(final Function1<T, F> func) {
-            return new Chain<F>($.newArrayList((Iterable<F>) $.uniq(value(), func)));
+        public <F> Chain<T> uniq(final Function1<T, F> func) {
+            return new Chain<T>($.newArrayList($.uniq(value(), func)));
         }
 
         public Chain<T> distinct() {


### PR DESCRIPTION
`$.uniq(Function1<T, F>)` returns an `Iterable<T>`, by using `F` as the uniqueness parameter. However, when using `Chain`, `Chain.uniq(Function1<T, F>)` returns an `Iterable<F>`. This PR fixes that and adds a test (in `ChainingTest`) to validate this behaviour.