### PR TITLE
Defining a universal filter() method

### DIFF
--- a/src/main/java/com/github/underscore/U.java
+++ b/src/main/java/com/github/underscore/U.java
@@ -435,9 +435,10 @@ public class U<T> {
     /*
      * Documented, #filter
      */
-    public static <E> List<E> filter(final List<E> list, final Predicate<E> pred) {
-        final List<E> filtered = newArrayList();
-        for (E element : list) {
+
+    public static <T, E extends Iterable<T>> Iterable<T> filter(final E iter, final Predicate<T> pred) {
+        final List<T> filtered = newArrayList();
+        for (T element : iter) {
             if (pred.test(element)) {
                 filtered.add(element);
             }
@@ -446,13 +447,7 @@ public class U<T> {
     }
 
     public List<T> filter(final Predicate<T> pred) {
-        final List<T> filtered = newArrayList();
-        for (final T element : value()) {
-            if (pred.test(element)) {
-                filtered.add(element);
-            }
-        }
-        return filtered;
+        return newArrayList(filter(value(), pred));
     }
 
     public static <E> List<E> filterIndexed(final List<E> list, final PredicateIndexed<E> pred) {
@@ -467,34 +462,24 @@ public class U<T> {
         return filtered;
     }
 
-    public static <E> Set<E> filter(final Set<E> set, final Predicate<E> pred) {
-        final Set<E> filtered = newLinkedHashSet();
-        for (E element : set) {
-            if (pred.test(element)) {
-                filtered.add(element);
-            }
-        }
-        return filtered;
-    }
-
     public static <E> List<E> select(final List<E> list, final Predicate<E> pred) {
-        return filter(list, pred);
+        return newArrayList(filter(list, pred));
     }
 
     public static <E> Set<E> select(final Set<E> set, final Predicate<E> pred) {
-        return filter(set, pred);
+        return newLinkedHashSet(filter(set, pred));
     }
 
     /*
      * Documented, #reject
      */
     public static <E> List<E> reject(final List<E> list, final Predicate<E> pred) {
-        return filter(list, new Predicate<E>() {
+        return newArrayList(filter(list, new Predicate<E>() {
             @Override
             public boolean test(E input) {
                 return !pred.test(input);
             }
-        });
+        }));
     }
 
     public List<T> reject(final Predicate<T> pred) {
@@ -516,12 +501,12 @@ public class U<T> {
     }
 
     public static <E> Set<E> reject(final Set<E> set, final Predicate<E> pred) {
-        return filter(set, new Predicate<E>() {
+        return newLinkedHashSet(filter(set, new Predicate<E>() {
             @Override
             public boolean test(E input) {
                 return !pred.test(input);
             }
-        });
+        }));
     }
 
     public static <E> List<E> filterFalse(final List<E> list, final Predicate<E> pred) {
@@ -710,7 +695,7 @@ public class U<T> {
      */
     public static <T, E> List<E> where(final List<E> list,
                                     final List<Tuple<String, T>> properties) {
-        return filter(list, new WherePredicate<E, T>(properties));
+        return newArrayList(filter(list, new WherePredicate<E, T>(properties)));
 
     }
 
@@ -720,7 +705,7 @@ public class U<T> {
 
     public static <T, E> Set<E> where(final Set<E> set,
                                    final List<Tuple<String, T>> properties) {
-        return filter(set, new WherePredicate<E, T>(properties));
+        return newLinkedHashSet(filter(set, new WherePredicate<E, T>(properties)));
     }
 
     /*
@@ -1149,7 +1134,7 @@ public class U<T> {
     }
 
     public static <E> E last(final List<E> list, final Predicate<E> pred) {
-        final List<E> filteredList = filter(list, pred);
+        final List<E> filteredList = newArrayList(filter(list, pred));
         return filteredList.get(filteredList.size() - 1);
     }
 
@@ -1166,7 +1151,7 @@ public class U<T> {
     }
 
     public static <E> E lastOrNull(final List<E> list, final Predicate<E> pred) {
-        final List<E> filteredList = filter(list, pred);
+        final List<E> filteredList = newArrayList(filter(list, pred));
         return filteredList.isEmpty() ? null : filteredList.get(filteredList.size() - 1);
     }
 
@@ -1249,13 +1234,13 @@ public class U<T> {
      * Documented, #compact
      */
     public static <E> List<E> compact(final List<E> list) {
-        return filter(list, new Predicate<E>() {
+        return newArrayList(filter(list, new Predicate<E>() {
             @Override
             public boolean test(E arg) {
                 return !String.valueOf(arg).equals("null") && !String.valueOf(arg).equals("0")
                     && !String.valueOf(arg).equals("false") && !String.valueOf(arg).equals("");
             }
-        });
+        }));
     }
 
     @SuppressWarnings("unchecked")
@@ -1264,12 +1249,12 @@ public class U<T> {
     }
 
     public static <E> List<E> compact(final List<E> list, final E falsyValue) {
-        return filter(list, new Predicate<E>() {
+        return newArrayList(filter(list, new Predicate<E>() {
             @Override
             public boolean test(E arg) {
                 return !(arg == null ? falsyValue == null : arg.equals(falsyValue));
             }
-        });
+        }));
     }
 
     @SuppressWarnings("unchecked")
@@ -1326,12 +1311,12 @@ public class U<T> {
     @SuppressWarnings("unchecked")
     public static <E> List<E> without(final List<E> list, E ... values) {
         final List<E> valuesList = Arrays.asList(values);
-        return filter(list, new Predicate<E>() {
+        return newArrayList(filter(list, new Predicate<E>() {
             @Override
             public boolean test(E elem) {
                 return !contains(valuesList, elem);
             }
-        });
+        }));
     }
 
     @SuppressWarnings("unchecked")
@@ -2449,7 +2434,7 @@ public class U<T> {
         }
 
         public Chain<T> filter(final Predicate<T> pred) {
-            return new Chain<T>(U.filter(list, pred));
+            return new Chain<T>(newArrayList(U.filter(list, pred)));
         }
 
         public Chain<T> filterIndexed(final PredicateIndexed<T> pred) {

--- a/src/main/java/com/github/underscore/lodash/U.java
+++ b/src/main/java/com/github/underscore/lodash/U.java
@@ -167,7 +167,7 @@ public class U<T> extends com.github.underscore.U<T> {
         }
 
         public Chain<T> filter(final Predicate<T> pred) {
-            return new Chain<T>(U.filter(value(), pred));
+            return new Chain<T>(newArrayList(U.filter(value(), pred)));
         }
 
         public Chain<T> filterIndexed(final PredicateIndexed<T> pred) {

--- a/src/test/java/com/github/underscore/CollectionsTest.java
+++ b/src/test/java/com/github/underscore/CollectionsTest.java
@@ -611,20 +611,19 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 
          class MyClass implements Iterable<Integer> {
 
-    		private Integer i;
+            private Integer i;
 
-			public MyClass(Integer i) {
-				this.i = i;
-			}
+            public MyClass(Integer i) {
+                this.i = i;
+            }
 
-			@Override
-			public Iterator<Integer> iterator() {
-				// TODO Auto-generated method stub
-				return asList(i, i * 2, i * 3, i * 4, i * 5).iterator();
-			}
+            @Override
+            public Iterator<Integer> iterator() {
+                return asList(i, i * 2, i * 3, i * 4, i * 5).iterator();
+            }
 
-    	}
-    	final Iterable<Integer> result = U.filter(new MyClass(5),
+        }
+        final Iterable<Integer> result = U.filter(new MyClass(5),
             new Predicate<Integer>() {
             public boolean test(Integer item) {
                 return item % 2 == 0;
@@ -653,14 +652,14 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
         });
         assertEquals("[1, 2]", result3.toString());
         final Iterable<Integer> result4 = U.filter(new Iterable<Integer>() {
-				@Override
-				public Iterator<Integer> iterator() {
-					return asList(1, 2, 3, 4, 5, 6).iterator();
-				}
-        	}, new Predicate<Integer>() {
-	            public boolean test(Integer item) {
-	                return item * item > 4;
-	            }
+                @Override
+                public Iterator<Integer> iterator() {
+                    return asList(1, 2, 3, 4, 5, 6).iterator();
+                }
+            }, new Predicate<Integer>() {
+                public boolean test(Integer item) {
+                    return item * item > 4;
+                }
         });
         assertEquals("[3, 4, 5, 6]", result4.toString());
         final List<Integer> resultObject = new U<Integer>(asList(1, 2, 3, 4, 5, 6))

--- a/src/test/java/com/github/underscore/CollectionsTest.java
+++ b/src/test/java/com/github/underscore/CollectionsTest.java
@@ -608,13 +608,62 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 */
     @Test
     public void filter() {
-        final List<Integer> result = U.filter(asList(1, 2, 3, 4, 5, 6),
+
+    	class MyClass implements Iterable<Integer> {
+
+    		private Integer i;
+    		
+			public MyClass(Integer i) {
+				this.i = i;
+			}
+
+			@Override
+			public Iterator<Integer> iterator() {
+				// TODO Auto-generated method stub
+				return asList(i, i * 2, i * 3, i * 4, i * 5).iterator();
+			}
+    		
+    	}
+    	final Iterable<Integer> result = U.filter(new MyClass(5),
             new Predicate<Integer>() {
             public boolean test(Integer item) {
                 return item % 2 == 0;
             }
         });
-        assertEquals("[2, 4, 6]", result.toString());
+        assertEquals("[10, 20]", result.toString());
+    	
+        final Iterable<Integer> result1 = U.filter(asList(1, 2, 3, 4, 5, 6),
+            new Predicate<Integer>() {
+            public boolean test(Integer item) {
+                return item % 2 == 0;
+            }
+        });
+        assertEquals("[2, 4, 6]", result1.toString());
+        final Iterable<Integer> result2 = U.filter(new PriorityQueue<Integer>(asList(1, 2, 3, 4, 5, 6)),
+        	new Predicate<Integer>() {
+            public boolean test(Integer item) {
+                return item > 2;
+            }
+        });
+        assertEquals("[3, 4, 5, 6]", result2.toString());
+        final Iterable<Integer> result3 = U.filter(new HashSet<Integer>(asList(1, 2, 3, 4, 5, 6)),
+        	new Predicate<Integer>() {
+            public boolean test(Integer item) {
+                return item <= 2;
+            }
+        });
+        assertEquals("[1, 2]", result3.toString());
+        final Iterable<Integer> result4 = U.filter(new Iterable<Integer>() {
+				@Override
+				public Iterator<Integer> iterator() {
+					return asList(1, 2, 3, 4, 5, 6).iterator();
+				}
+        	},new Predicate<Integer>() {
+	            public boolean test(Integer item) {
+	                return item * item > 4;
+	            }
+        });
+        assertEquals("[3, 4, 5, 6]", result4.toString());
         final List<Integer> resultObject = new U<Integer>(asList(1, 2, 3, 4, 5, 6))
             .filter(new Predicate<Integer>() {
             public boolean test(Integer item) {

--- a/src/test/java/com/github/underscore/CollectionsTest.java
+++ b/src/test/java/com/github/underscore/CollectionsTest.java
@@ -609,10 +609,10 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
     @Test
     public void filter() {
 
-    	class MyClass implements Iterable<Integer> {
+         class MyClass implements Iterable<Integer> {
 
     		private Integer i;
-    		
+
 			public MyClass(Integer i) {
 				this.i = i;
 			}
@@ -622,7 +622,7 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 				// TODO Auto-generated method stub
 				return asList(i, i * 2, i * 3, i * 4, i * 5).iterator();
 			}
-    		
+
     	}
     	final Iterable<Integer> result = U.filter(new MyClass(5),
             new Predicate<Integer>() {
@@ -631,7 +631,6 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
             }
         });
         assertEquals("[10, 20]", result.toString());
-    	
         final Iterable<Integer> result1 = U.filter(asList(1, 2, 3, 4, 5, 6),
             new Predicate<Integer>() {
             public boolean test(Integer item) {
@@ -658,7 +657,7 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
 				public Iterator<Integer> iterator() {
 					return asList(1, 2, 3, 4, 5, 6).iterator();
 				}
-        	},new Predicate<Integer>() {
+        	}, new Predicate<Integer>() {
 	            public boolean test(Integer item) {
 	                return item * item > 4;
 	            }

--- a/src/test/java/com/github/underscore/CollectionsTest.java
+++ b/src/test/java/com/github/underscore/CollectionsTest.java
@@ -638,14 +638,14 @@ var evens = _.filter([1, 2, 3, 4, 5, 6], function(num){ return num % 2 == 0; });
         });
         assertEquals("[2, 4, 6]", result1.toString());
         final Iterable<Integer> result2 = U.filter(new PriorityQueue<Integer>(asList(1, 2, 3, 4, 5, 6)),
-        	new Predicate<Integer>() {
+            new Predicate<Integer>() {
             public boolean test(Integer item) {
                 return item > 2;
             }
         });
         assertEquals("[3, 4, 5, 6]", result2.toString());
         final Iterable<Integer> result3 = U.filter(new HashSet<Integer>(asList(1, 2, 3, 4, 5, 6)),
-        	new Predicate<Integer>() {
+            new Predicate<Integer>() {
             public boolean test(Integer item) {
                 return item <= 2;
             }

--- a/src/test/java/com/github/underscore/ObjectsTest.java
+++ b/src/test/java/com/github/underscore/ObjectsTest.java
@@ -441,7 +441,7 @@ var readyToGoList = _.filter(list, ready);
         );
         Predicate<Map<String, Object>> ready = U.matcher(new LinkedHashMap<String, Object>() { {
             put("selected", true); put("visible", true); } });
-        List<Map<String, Object>> result = U.filter(list, ready);
+        List<Map<String, Object>> result = U.newArrayList(U.filter(list, ready));
         assertEquals("[{name=moe, selected=true, visible=true}]", result.toString());
     }
 


### PR DESCRIPTION
In this change I implemented a new filter method. In the previous versions, we cannot call the filter method with our own class. Now, we can do this. See an example in the test file.