### PR TITLE
Add splitAt() method

### DIFF
--- a/src/main/java/com/github/underscore/U.java
+++ b/src/main/java/com/github/underscore/U.java
@@ -2939,6 +2939,10 @@ public class U<T> {
             return new Chain<T>(U.slice(list, start, end));
         }
 
+        public Chain<List<T>> splitAt(final int position) {
+            return new Chain<List<T>>(U.splitAt(list, position));
+        }
+
         public Chain<T> reverse() {
             return new Chain<T>(U.reverse(list));
         }
@@ -3229,6 +3233,23 @@ public class U<T> {
 
     public List<T> slice(final int start, final int end) {
         return slice(iterable, start, end);
+    }
+
+    public static <T> List<List<T>> splitAt(final Iterable<T> iterable, final int position) {
+        List<List<T>> result = newArrayList();
+        int size = size(iterable);
+        int index = position < 0 ? 0 : (position > size ? size : position);
+        result.add(newArrayList(iterable).subList(0, index));
+        result.add(newArrayList(iterable).subList(index, size));
+        return result;
+    }
+
+    public static <T> List<List<T>> splitAt(final T[] array, final int position) {
+        return splitAt(Arrays.asList(array), position);
+    }
+
+    public List<List<T>> splitAt(final int position) {
+        return splitAt(iterable, position);
     }
 
     /*

--- a/src/test/java/com/github/underscore/UnderscoreTest.java
+++ b/src/test/java/com/github/underscore/UnderscoreTest.java
@@ -188,6 +188,34 @@ arr.slice(-3, -1) // [3, 4]
     }
 
 /*
+_.splitAt([1, 2, 3, 4, 5], 2);
+=> [[1, 2], [3, 4, 5]]
+_.splitAt([1, 2, 3, 4, 5], 0);
+=> [[], [1, 2, 3, 4, 5]]
+_.splitAt([1, 2, 3, 4, 5], 20000);
+=> [[1, 2, 3, 4, 5], []]
+_.splitAt([1, 2, 3, 4, 5], -1000);
+=> [[], [1, 2, 3, 4, 5]]
+_.splitAt([], 0);
+=> [[], []]
+*/
+    @Test
+    public void splitAt() {
+        assertEquals("[[0, 1], [2, 3, 4]]", U.splitAt(U.newIntegerList(U.range(5)), 2).toString());
+        assertEquals("[[], [0, 1, 2, 3, 4]]", U.splitAt(U.newIntegerList(U.range(5)), 0).toString());
+        assertEquals("[[0, 1, 2, 3, 4], []]", U.splitAt(U.newIntegerList(U.range(5)), 20000).toString());
+        assertEquals("[[], [0, 1, 2, 3, 4]]", U.splitAt(U.newIntegerList(U.range(5)), -1000).toString());
+        assertEquals("[[], []]", U.splitAt(U.newIntegerList(), 0).toString());
+        assertEquals("[[0, 1], [2, 3, 4]]", new U<Integer>(U.newIntegerList(U.range(5))).splitAt(2).toString());
+        assertEquals("[[0, 1], [2, 3, 4]]", U.chain(U.newIntegerList(U.range(5))).splitAt(2).value().toString());
+        assertEquals("[[a, b], [c, d, e]]", U.splitAt(asList('a', 'b', 'c', 'd', 'e'), 2).toString());
+        assertEquals("[[ant, bird], [camel, dog, elephant]]", U.splitAt(asList("ant", "bird", "camel", "dog", "elephant"), 2).toString());
+        assertEquals("[[0.1, 0.2], [0.3, 0.4, 0.5]]", U.splitAt(asList(0.1, 0.2, 0.3, 0.4, 0.5), 2).toString());
+        final Integer[] array = {0, 1, 2, 3, 4};
+        assertEquals("[[0, 1], [2, 3, 4]]", U.splitAt(array, 2).toString());
+    }
+
+/*
 var arr = [ 1, 2, 3 ]
 _.copyOf(arr) // => [1, 2, 3]
 */


### PR DESCRIPTION
In this change I created the splitAt() method.
This function takes an array or a list and a numeric index and returns a new list with two embedded lists representing a split of the original array/list at the index provided.