### PR TITLE
[fix] Xml#getRootName returns null, although there is more than one element.

### DIFF
--- a/src/main/java/com/github/underscore/lodash/Xml.java
+++ b/src/main/java/com/github/underscore/lodash/Xml.java
@@ -960,18 +960,21 @@ public final class Xml {
     private static String getRootName(final Map localMap) {
         int foundAttrs = 0;
         int foundElements = 0;
+        int foundListElements = 0;
         if (localMap != null) {
             for (Map.Entry entry : (Set<Map.Entry>) localMap.entrySet()) {
                 if (String.valueOf(entry.getKey()).startsWith("-")) {
                     foundAttrs += 1;
                 } else if (!String.valueOf(entry.getKey()).startsWith(COMMENT)
-                        && !String.valueOf(entry.getKey()).startsWith("?")
-                        && (!(entry.getValue() instanceof List) || ((List) entry.getValue()).size() <= 1)) {
+                        && !String.valueOf(entry.getKey()).startsWith("?")) {
+                    if (entry.getValue() instanceof List && ((List) entry.getValue()).size() > 1) {
+                        foundListElements += 1;
+                    }
                     foundElements += 1;
                 }
             }
         }
-        return foundAttrs == 0 && foundElements == 1 ? null : "root";
+        return foundAttrs == 0 && foundElements == 1 && foundListElements == 0 ? null : "root";
     }
 
     public static String toXml(Map map) {

--- a/src/test/java/com/github/underscore/lodash/LodashTest.java
+++ b/src/test/java/com/github/underscore/lodash/LodashTest.java
@@ -600,6 +600,16 @@ _.get({"a":[{"b":{"c":"d"}}]}, "a[0].b.c");
             U.chain("{\n  \"a\": {\n  }\n}").jsonToXml().item());
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root empty-array=\"true\"></root>",
             U.jsonToXml("[]"));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<root>\n"
+                + "  <a>\n"
+                + "    <b>v1</b>\n"
+                + "  </a>\n"
+                + "  <c>v1</c>\n"
+                + "  <c>v2</c>\n"
+                + "  <c>v3</c>\n"
+                + "</root>",
+            U.jsonToXml("{\"a\" : {\n \"b\" : \"v1\" }, \"c\" : [\"v1\", \"v2\", \"v3\"]}"));
     }
 
     @Test


### PR DESCRIPTION
If there are two or more elements in the map and all elements except one are of type List, the method returns null, resulting in invalid XML due to the missing root element.

Without this fix, the following JSON results to invalid XML:
```json
{
  "a": {
    "b": "v1" 
  },
  "c": ["v1", "v2", "v2"]
}
```
```xml
<?xml version="1.0" encoding="UTF-8"?>
<a>
  <b>v1</b>
</a>
<c>v1</c>
<c>v2</c>
<c>v2</c>
```

@javadev mind taking a look.