### PR TITLE
Template should not fail when value has dollar

### DIFF
--- a/src/main/java/com/github/underscore/U.java
+++ b/src/main/java/com/github/underscore/U.java
@@ -156,7 +156,8 @@ public class U<T> {
             final String escape = TEMPLATE_SETTINGS.get(ESCAPE);
             String result = template;
             for (final Map.Entry<K, V> element : value.entrySet()) {
-                final String value1 = String.valueOf(element.getValue()).replace("\\", "\\\\");
+                final String value1 = String.valueOf(element.getValue()).replace("\\", "\\\\")
+                        .replace("$", "\\$");
                 result = java.util.regex.Pattern.compile(interpolate.replace(ALL_SYMBOLS,
                     S_Q + element.getKey()
                     + E_S)).matcher(result).replaceAll(value1);

--- a/src/test/java/com/github/underscore/UtilityTest.java
+++ b/src/test/java/com/github/underscore/UtilityTest.java
@@ -252,6 +252,15 @@ template({value: '<script>'});
     }
 
     @Test
+    public void templateValue4() {
+        Template<Map<String, Object>> template = U.template("hello: <% name %>, <b><%- value %></b>");
+        assertEquals("hello: $moe$, <b>&lt;script&gt;</b>",
+                template.apply(new LinkedHashMap<String, Object>() { {
+                    put("name", "$moe$"); put("value", "<script>"); } }));
+    }
+
+
+    @Test
     public void templateCheck() {
         Template<Map<String, Object>> compiled = U.template("hello: <%= name %>");
         assertTrue(compiled.check(new LinkedHashMap<String, Object>() { {


### PR DESCRIPTION
The template uses java regular expression replace to insert the values. The java replaceAll method treats the $ symbol
as a variable for inserting capturing groups. When a dollar symbol is passed in the value part java tries to treat it as
capturing group and fails with an exception.

This fix escapes the $ symbol before it is used