### PR TITLE
Add overrides for U.get, U.set and U.remove

### DIFF
--- a/src/main/java/com/github/underscore/U.java
+++ b/src/main/java/com/github/underscore/U.java
@@ -564,6 +564,11 @@ public class U<T> extends Underscore<T> {
             return new Chain<>(Underscore.slice(value(), start, end));
         }
 
+        public Chain<Map<String, Object>> set(final List<String> paths, Object value) {
+            U.set(map(), paths, value);
+            return new Chain<>(map());
+        }
+
         public Chain<Map<String, Object>> set(final String path, Object value) {
             U.set(map(), path, value);
             return new Chain<>(map());
@@ -1715,10 +1720,9 @@ public class U<T> extends Underscore<T> {
     @SuppressWarnings("unchecked")
     private static <T> T baseGetOrSetOrRemove(
             final Map<String, Object> object,
-            final String path,
+            final List<String> paths,
             final Object value,
             OperationType operationType) {
-        final List<String> paths = stringToPath(path);
         int index = 0;
         final int length = paths.size();
 
@@ -1774,15 +1778,30 @@ public class U<T> extends Underscore<T> {
     }
 
     public static <T> T get(final Map<String, Object> object, final String path) {
-        return baseGetOrSetOrRemove(object, path, null, OperationType.GET);
+        final List<String> paths = stringToPath(path);
+        return get(object, paths);
+    }
+
+    public static <T> T get(final Map<String, Object> object, final List<String> paths) {
+        return baseGetOrSetOrRemove(object, paths, null, OperationType.GET);
     }
 
     public static <T> T set(final Map<String, Object> object, final String path, Object value) {
-        return baseGetOrSetOrRemove(object, path, value, OperationType.SET);
+        final List<String> paths = stringToPath(path);
+        return set(object, paths, value);
+    }
+
+    public static <T> T set(final Map<String, Object> object, final List<String> paths, Object value) {
+        return baseGetOrSetOrRemove(object, paths, value, OperationType.SET);
     }
 
     public static <T> T remove(final Map<String, Object> object, final String path) {
-        return baseGetOrSetOrRemove(object, path, null, OperationType.REMOVE);
+        final List<String> paths = stringToPath(path);
+        return remove(object, paths);
+    }
+
+    public static <T> T remove(final Map<String, Object> object, final List<String> paths) {
+        return baseGetOrSetOrRemove(object, paths, null, OperationType.REMOVE);
     }
 
     public static Map<String, Object> rename(
@@ -3115,12 +3134,26 @@ public class U<T> extends Underscore<T> {
             return this;
         }
 
+        public <T> T get(final List<String> paths) {
+            return U.get(data, paths);
+        }
+
         public <T> T get(final String path) {
             return U.get(data, path);
         }
 
+        public Builder set(final List<String> paths, final Object value) {
+            U.set(data, paths, value);
+            return this;
+        }
+
         public Builder set(final String path, final Object value) {
             U.set(data, path, value);
+            return this;
+        }
+
+        public Builder remove(final List<String> keys) {
+            U.remove(data, keys);
             return this;
         }
 
@@ -3232,6 +3265,13 @@ public class U<T> extends Underscore<T> {
         public ArrayBuilder addNull() {
             data.add(null);
             return this;
+        }
+
+        public <T> T get(final List<String> paths) {
+            List<String> newPaths = new ArrayList<>();
+            newPaths.add("value");
+            newPaths.addAll(paths);
+            return U.get(U.getStringObjectMap(data), newPaths);
         }
 
         public <T> T get(final String path) {


### PR DESCRIPTION
Accept paths as a List<String>, for it its more useful than parsing a complex regex.

One problem of parsing a regex is that you may have a valid separator as part of a key from your map. For example, if a key is an email, you could get in trouble for using some email ending in something.com.